### PR TITLE
chore: add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
 	"dependencies": {
 		"bash-glob": "^2.0.0",
 		"blork": "^9.1.1",
+		"cosmiconfig": "^5.1.0",
 		"execa": "^1.0.0",
 		"get-stream": "^4.1.0",
 		"git-log-parser": "^1.2.0",
 		"jest": "^23.6.0",
+		"require-in-the-middle": "^4.0.0",
 		"semantic-release": "^15.12.4",
 		"semver": "^5.6.0",
 		"signale": "^1.2.0",


### PR DESCRIPTION
When using `multi-semantic-release` in a project where another dependency use an older version of `cosmiconfig` the application breaks with the error

```
[multi-semantic-release]: TypeError: cosmiconfig(...).search is not a function
```

This PR ensure that `multi-semantic-release` uses a compatible version and that does not rely on the fact that `cosmiconfig` is a `semantic-release` dependency