### PR TITLE
fix: filter queued packages on generateNotes step

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -179,7 +179,7 @@ function createInlinePluginCreator(packages, multiContext) {
 			pkg._nextRelease = context.nextRelease;
 
 			// Wait until all todo packages are ready to generate notes.
-			await waitFor("_nextRelease");
+			await waitFor("_nextRelease", (p) => p._nextType);
 
 			if (todo()[0] !== pkg) {
 				await pkg._readyForRelease;

--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -1,6 +1,5 @@
 const { writeFileSync } = require("fs");
-const { once } = require("lodash");
-const { identity } = require("lodash");
+const { identity, once } = require("lodash");
 const EventEmitter = require("promise-events");
 const getCommitsFiltered = require("./getCommitsFiltered");
 const getManifest = require("./getManifest");

--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -1,4 +1,5 @@
 const { writeFileSync } = require("fs");
+const { once } = require("lodash");
 const { identity } = require("lodash");
 const EventEmitter = require("promise-events");
 const getCommitsFiltered = require("./getCommitsFiltered");
@@ -27,6 +28,9 @@ function createInlinePluginCreator(packages, multiContext) {
 
 	// Announcement of readiness for release.
 	todo().forEach((p) => (p._readyForRelease = ee.once(p.name)));
+
+	// The first lucky package to be released is marked as `readyForRelease`
+	const ignition = once((name) => ee.emit(name));
 
 	// Status sync point.
 	const waitFor = (prop, filter = identity) => {
@@ -181,9 +185,9 @@ function createInlinePluginCreator(packages, multiContext) {
 			// Wait until all todo packages are ready to generate notes.
 			await waitFor("_nextRelease", (p) => p._nextType);
 
-			if (todo()[0] !== pkg) {
-				await pkg._readyForRelease;
-			}
+			// Wait until the current pkg is ready to generate notes
+			ignition(pkg.name);
+			await pkg._readyForRelease;
 
 			// Update pkg deps.
 			updateManifestDeps(pkg, path);


### PR DESCRIPTION
`generateNotes` **waitFor** condition might be unreachable if some packages do not require release, but hang up and still present `todo` queue.
**semrel**
```javascript
const nextRelease = {
    type: await plugins.analyzeCommits(context),
    channel: context.branch.channel || null,
    gitHead: await getGitHead({cwd, env}),
  };
  if (!nextRelease.type) {
    logger.log('There are no relevant changes, so no new version is released.');
    return context.releases.length > 0 ? {releases: context.releases} : false;
  }
```

**multi-semrel**
```javascript
		const generateNotes = async (pluginOptions, context) => {
			// Set nextRelease for package.
			pkg._nextRelease = context.nextRelease;

			// Wait until all todo packages are ready to generate notes.
			await waitFor("_nextRelease");
```
So packages must be filtered by `(p) => p._nextType`.