### PR TITLE
fix(lib): package json files were being minified by plugin creator

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -73,7 +73,7 @@ function createInlinePluginCreator(packages, multiContext) {
 		});
 
 		// Write package.json back out.
-		writeFileSync(path, JSON.stringify(manifest));
+		writeFileSync(path, JSON.stringify(manifest, null, 2));
 	};
 
 	/**


### PR DESCRIPTION
the package file is read / a written when the inline plugin is used.
By default json strigify doesn't not have any formatting. This results
in the package file effectively beign minified. This change introduces
simple formatting w/ a 2 space indent

Semver: patch