### PR TITLE
fix: load package-specific options correctly

### DIFF
--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -64,8 +64,7 @@ async function multiSemanticRelease(
 
 	// Vars.
 	const globalOptions = await getConfig(cwd);
-	const options = Object.assign({}, globalOptions, inputOptions);
-	const multiContext = { options, cwd, env, stdout, stderr };
+	const multiContext = { globalOptions, inputOptions, cwd, env, stdout, stderr };
 
 	// Load packages from paths.
 	const packages = await Promise.all(paths.map((path) => getPackage(path, multiContext)));
@@ -118,7 +117,7 @@ module.exports = multiSemanticRelease;
  *
  * @internal
  */
-async function getPackage(path, { options: globalOptions, env, cwd, stdout, stderr }) {
+async function getPackage(path, { globalOptions, inputOptions, env, cwd, stdout, stderr }) {
 	// Make path absolute.
 	path = cleanPath(path, cwd);
 	const dir = dirname(path);
@@ -135,15 +134,19 @@ async function getPackage(path, { options: globalOptions, env, cwd, stdout, stde
 		...manifest.optionalDependencies,
 	});
 
+	// Load the package-specific options.
+	const pkgOptions = await getConfig(dir);
+
+	// The 'final options' are the global options merged with package-specific options.
+	// We merge this ourselves because package-specific options can override global options.
+	const finalOptions = Object.assign({}, globalOptions, pkgOptions, inputOptions);
+
 	// Make a fake logger so semantic-release's get-config doesn't fail.
 	const logger = { error() {}, log() {} };
 
 	// Use semantic-release's internal config (now we have the right `options.plugins` setting) to get the plugins object and the package options including defaults.
 	// We need this so we can call e.g. plugins.analyzeCommit() to be able to affect the input and output of the whole set of plugins.
-	const { options: pkgOptions, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger });
-
-	// Merge the package options with the global options.
-	const options = { ...globalOptions, ...pkgOptions };
+	const { options, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger }, finalOptions);
 
 	// Return package object.
 	return { path, dir, name, manifest, deps, options, plugins, loggerRef: logger };

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -136,7 +136,7 @@ async function getPackage(path, { options: globalOptions, env, cwd, stdout, stde
 	});
 
 	// Load the package-specific options.
-	const { options: pkgOptions } = await getConfig(dir);
+	const pkgOptions = await getConfig(dir);
 
 	// The 'final options' are the global options merged with package-specific options.
 	// We merge this ourselves because package-specific options can override global options.

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -138,10 +138,12 @@ async function getPackage(path, { options: globalOptions, env, cwd, stdout, stde
 	// Make a fake logger so semantic-release's get-config doesn't fail.
 	const logger = { error() {}, log() {} };
 
-	// Use semantic-release's internal config with the global options (now we have the right `options.plugins` setting) to get the plugins object and the options including defaults.
-	// There's no need to get the options for the package individually because semantic-release already does this.
+	// Use semantic-release's internal config (now we have the right `options.plugins` setting) to get the plugins object and the package options including defaults.
 	// We need this so we can call e.g. plugins.analyzeCommit() to be able to affect the input and output of the whole set of plugins.
-	const { options, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger }, globalOptions);
+	const { options: pkgOptions, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger });
+
+	// Merge the package options with the global options.
+	const options = { ...globalOptions, ...pkgOptions };
 
 	// Return package object.
 	return { path, dir, name, manifest, deps, options, plugins, loggerRef: logger };

--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -135,19 +135,13 @@ async function getPackage(path, { options: globalOptions, env, cwd, stdout, stde
 		...manifest.optionalDependencies,
 	});
 
-	// Load the package-specific options.
-	const pkgOptions = await getConfig(dir);
-
-	// The 'final options' are the global options merged with package-specific options.
-	// We merge this ourselves because package-specific options can override global options.
-	const finalOptions = Object.assign({}, globalOptions, pkgOptions);
-
 	// Make a fake logger so semantic-release's get-config doesn't fail.
 	const logger = { error() {}, log() {} };
 
-	// Use semantic-release's internal config with the final options (now we have the right `options.plugins` setting) to get the plugins object and the options including defaults.
+	// Use semantic-release's internal config with the global options (now we have the right `options.plugins` setting) to get the plugins object and the options including defaults.
+	// There's no need to get the options for the package individually because semantic-release already does this.
 	// We need this so we can call e.g. plugins.analyzeCommit() to be able to affect the input and output of the whole set of plugins.
-	const { options, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger }, finalOptions);
+	const { options, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger }, globalOptions);
 
 	// Return package object.
 	return { path, dir, name, manifest, deps, options, plugins, loggerRef: logger };

--- a/test/fixtures/badYarnWorkspaces/package.json
+++ b/test/fixtures/badYarnWorkspaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msr-test-yarn-bad",
-	"author": "Dave Houlbrooke <dave@shax.com",
+	"author": "Dave Houlbrooke <dave@shax.com>",
 	"version": "0.0.0-semantically-released",
 	"private": true,
 	"license": "0BSD",

--- a/test/fixtures/emptyYarnWorkspaces/package.json
+++ b/test/fixtures/emptyYarnWorkspaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msr-test-yarn-empty",
-	"author": "Dave Houlbrooke <dave@shax.com",
+	"author": "Dave Houlbrooke <dave@shax.com>",
 	"version": "0.0.0-semantically-released",
 	"private": true,
 	"license": "0BSD",

--- a/test/fixtures/packageOptions/package.json
+++ b/test/fixtures/packageOptions/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "msr-test-package-options",
+	"author": "Dave Houlbrooke <dave@shax.com>",
+	"version": "0.0.0-semantically-released",
+	"private": true,
+	"license": "0BSD",
+	"engines": {
+		"node": ">=8.3"
+	},
+	"workspaces": [
+		"packages/*"
+	],
+	"release": {
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator"
+		],
+		"noCi": true
+	}
+}

--- a/test/fixtures/packageOptions/packages/a/package.json
+++ b/test/fixtures/packageOptions/packages/a/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-a",
+	"version": "0.0.0"
+}

--- a/test/fixtures/packageOptions/packages/b/.releaserc.json
+++ b/test/fixtures/packageOptions/packages/b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        {"type": "docs", "release": "patch"}
+      ]
+    }],
+    "@semantic-release/release-notes-generator"
+  ]
+}

--- a/test/fixtures/packageOptions/packages/b/package.json
+++ b/test/fixtures/packageOptions/packages/b/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-b",
+	"version": "0.0.0"
+}

--- a/test/fixtures/undefinedYarnWorkspaces/package.json
+++ b/test/fixtures/undefinedYarnWorkspaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msr-test-yarn-undefined",
-	"author": "Dave Houlbrooke <dave@shax.com",
+	"author": "Dave Houlbrooke <dave@shax.com>",
 	"version": "0.0.0-semantically-released",
 	"private": true,
 	"license": "0BSD",

--- a/test/fixtures/yarnWorkspaces/package.json
+++ b/test/fixtures/yarnWorkspaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msr-test-yarn",
-	"author": "Dave Houlbrooke <dave@shax.com",
+	"author": "Dave Houlbrooke <dave@shax.com>",
 	"version": "0.0.0-semantically-released",
 	"private": true,
 	"license": "0BSD",

--- a/test/fixtures/yarnWorkspacesPackages/package.json
+++ b/test/fixtures/yarnWorkspacesPackages/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msr-test-yarn",
-	"author": "Dave Houlbrooke <dave@shax.com",
+	"author": "Dave Houlbrooke <dave@shax.com>",
 	"version": "0.0.0-semantically-released",
 	"private": true,
 	"license": "0BSD",


### PR DESCRIPTION
There isn't an `options` property returned by `getConfig`, so this commit uses `const pkgOptions =
await getConfig(dir)` instead of `const { options: pkgOptions } = await getConfig(dir)`.

Previously, `pkgOptions` would always be `undefined`, so no package-specific options would actually be loaded.