### PR TITLE
fix: support merge workflows in generateNotes

### DIFF
--- a/lib/createInlinePluginCreator.js
+++ b/lib/createInlinePluginCreator.js
@@ -1,5 +1,6 @@
 const debug = require("debug")("msr:inlinePlugin");
 const getCommitsFiltered = require("./getCommitsFiltered");
+const { getTagHead } = require("./git");
 const { updateManifestDeps, resolveReleaseType } = require("./updateDeps");
 
 /**
@@ -41,11 +42,6 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 		};
 
 		/**
-		 * @var {Commit[]} List of _filtered_ commits that only apply to this package.
-		 */
-		let commits;
-
-		/**
 		 * @param {object} pluginOptions Options to configure this plugin.
 		 * @param {object} context The semantic-release context.
 		 * @returns {Promise<void>} void
@@ -85,12 +81,18 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 		 * @internal
 		 */
 		const analyzeCommits = async (pluginOptions, context) => {
-			const firstParentBranch = flags.firstParent ? context.branch.name : undefined;
 			pkg._preRelease = context.branch.prerelease || null;
 			pkg._branch = context.branch.name;
 
 			// Filter commits by directory.
-			commits = await getCommitsFiltered(cwd, dir, context.lastRelease.gitHead, firstParentBranch);
+			const firstParentBranch = flags.firstParent ? context.branch.name : undefined;
+			const commits = await getCommitsFiltered(
+				cwd,
+				dir,
+				context.lastRelease ? context.lastRelease.gitHead : undefined,
+				context.nextRelease ? context.nextRelease.gitHead : undefined,
+				firstParentBranch
+			);
 
 			// Set context.commits so analyzeCommits does correct analysis.
 			context.commits = commits;
@@ -151,8 +153,27 @@ function createInlinePluginCreator(packages, multiContext, synchronizer, flags) 
 			// Vars.
 			const notes = [];
 
-			// Set context.commits so analyzeCommits does correct analysis.
-			// We need to redo this because context is a different instance each time.
+			//get SHA of lastRelease if not already there (should have been done by Semantic Release...)
+			if (context.lastRelease && context.lastRelease.gitTag) {
+				if (!context.lastRelease.gitHead || context.lastRelease.gitHead === context.lastRelease.gitTag) {
+					context.lastRelease.gitHead = await getTagHead(context.lastRelease.gitTag, {
+						cwd: context.cwd,
+						env: context.env,
+					});
+				}
+			}
+
+			// Filter commits by directory (and release range)
+			const firstParentBranch = flags.firstParent ? context.branch.name : undefined;
+			const commits = await getCommitsFiltered(
+				cwd,
+				dir,
+				context.lastRelease ? context.lastRelease.gitHead : undefined,
+				context.nextRelease ? context.nextRelease.gitHead : undefined,
+				firstParentBranch
+			);
+
+			// Set context.commits so generateNotes does correct analysis.
 			context.commits = commits;
 
 			// Get subnotes and add to list.

--- a/lib/getCommitsFiltered.js
+++ b/lib/getCommitsFiltered.js
@@ -14,18 +14,20 @@ const debug = require("debug")("msr:commitsFilter");
  *
  * @param {string} cwd Absolute path of the working directory the Git repo is in.
  * @param {string} dir Path to the target directory to filter by. Either absolute, or relative to cwd param.
- * @param {string|void} lastHead The SHA of the previous release
+ * @param {string|void} lastRelease The SHA of the previous release (default to start of all commits if undefined)
+ * @param {string|void} nextRelease The SHA of the next release (default to HEAD if undefined)
  * @param {string|void} firstParentBranch first-parent to determine which merges went into master
  * @return {Promise<Array<Commit>>} The list of commits on the branch `branch` since the last release.
  */
-async function getCommitsFiltered(cwd, dir, lastHead = undefined, firstParentBranch) {
+async function getCommitsFiltered(cwd, dir, lastRelease, nextRelease, firstParentBranch) {
 	// Clean paths and make sure directories exist.
 	check(cwd, "cwd: directory");
 	check(dir, "dir: path");
 	cwd = cleanPath(cwd);
 	dir = cleanPath(dir, cwd);
 	check(dir, "dir: directory");
-	check(lastHead, "lastHead: alphanumeric{40}?");
+	check(lastRelease, "lastRelease: alphanumeric{40}?");
+	check(nextRelease, "nextRelease: alphanumeric{40}?");
 
 	// target must be inside and different than cwd.
 	if (dir.indexOf(cwd) !== 0) throw new ValueError("dir: Must be inside cwd", dir);
@@ -45,7 +47,8 @@ async function getCommitsFiltered(cwd, dir, lastHead = undefined, firstParentBra
 	// Use git-log-parser to get the commits.
 	const relpath = relative(root, dir);
 	const firstParentBranchFilter = firstParentBranch ? ["--first-parent", firstParentBranch] : [];
-	const gitLogFilterQuery = [...firstParentBranchFilter, lastHead ? `${lastHead}..HEAD` : "HEAD", "--", relpath];
+	const range = (lastRelease ? `${lastRelease}..` : "") + (nextRelease || "HEAD");
+	const gitLogFilterQuery = [...firstParentBranchFilter, range, "--", relpath];
 	const stream = gitLogParser.parse({ _: gitLogFilterQuery }, { cwd, env: process.env });
 	const commits = await getStream.array(stream);
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -25,6 +25,19 @@ function getTags(branch, execaOptions, filters) {
 	return tags.filter((tag) => validateSubstr(tag, filters));
 }
 
+/**
+ * Get the commit sha for a given tag.
+ *
+ * @param {String} tagName Tag name for which to retrieve the commit sha.
+ * @param {Object} [execaOptions] Options to pass to `execa`.
+ *
+ * @return {Promise<String>} The commit sha of the tag in parameter or `null`.
+ */
+async function getTagHead(tagName, execaOptions) {
+	return (await execa("git", ["rev-list", "-1", tagName], execaOptions)).stdout;
+}
+
 module.exports = {
 	getTags,
+	getTagHead,
 };


### PR DESCRIPTION
Fixes #64 

The fix is to allow getFilteredCommits to filter based on folder and _both_ lastRelease and nextRelease. This allows generateNotes to filter commits for earlier (merged) releases.

Additionally I needed to copy the getTagHead method from Semantic-Release as they have forgotten to do that on the lastRelease in merge situations...

Added some test cases to support this flow (though I didn't add a full merge scenario)