### PR TITLE
resolveNextVersion should provide bumpStrategy instead of releaseStrategy

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -178,7 +178,7 @@ const getDependentRelease = (pkg, bumpStrategy, releaseStrategy, ignore) => {
 			return false;
 		}
 
-		const resolvedVersion = resolveNextVersion(currentVersion, nextVersion, releaseStrategy);
+		const resolvedVersion = resolveNextVersion(currentVersion, nextVersion, bumpStrategy);
 		if (currentVersion !== resolvedVersion) {
 			scope[name] = resolvedVersion;
 			return true;

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -220,22 +220,22 @@ const getDependentRelease = (pkg, bumpStrategy, releaseStrategy, ignore) => {
  *
  * @param {string} currentVersion Current dep version
  * @param {string} nextVersion Next release type: patch, minor, major
- * @param {string|undefined} strategy Resolution strategy: inherit, override, satisfy
+ * @param {string|undefined} bumpStrategy Resolution strategy: inherit, override, satisfy
  * @returns {string} Next dependency version
  * @internal
  */
-const resolveNextVersion = (currentVersion, nextVersion, strategy = "override") => {
+const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "override") => {
 	// Check the next pkg version against its current references.
 	// If it matches (`*` matches to any, `1.1.0` matches `1.1.x`, `1.5.0` matches to `^1.0.0` and so on)
 	// release will not be triggered, if not `override` strategy will be applied instead.
-	if ((strategy === "satisfy" || strategy === "inherit") && semver.satisfies(nextVersion, currentVersion)) {
+	if ((bumpStrategy === "satisfy" || bumpStrategy === "inherit") && semver.satisfies(nextVersion, currentVersion)) {
 		return currentVersion;
 	}
 
 	// `inherit` will try to follow the current declaration version/range.
 	// `~1.0.0` + `minor` turns into `~1.1.0`, `1.x` + `major` gives `2.x`,
 	// but `1.x` + `minor` gives `1.x` so there will be no release, etc.
-	if (strategy === "inherit") {
+	if (bumpStrategy === "inherit") {
 		const sep = ".";
 		const nextChunks = nextVersion.split(sep);
 		const currentChunks = currentVersion.split(sep);


### PR DESCRIPTION
[`resolveNextVersion(currentVersion, nextVersion, strategy = "override")`](https://github.com/dhoulb/multi-semantic-release/blob/31f468e92c796418e0d4afaa5f77bc370fe972fb/lib/updateDeps.js#L227)'s strategy accept bump strategy: inherit, override, satisfy`, but [getDependentRelease](https://github.com/dhoulb/multi-semantic-release/blob/31f468e92c796418e0d4afaa5f77bc370fe972fb/lib/updateDeps.js#L181) invoke resolveNextVersion with release strategy: patch, minor, major, inherit. 