### PR TITLE
fix: ignore private packages

### DIFF
--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -67,7 +67,15 @@ async function multiSemanticRelease(
 	const multiContext = { globalOptions, inputOptions, cwd, env, stdout, stderr };
 
 	// Load packages from paths.
-	const packages = await Promise.all(paths.map((path) => getPackage(path, multiContext)));
+	const allPackages = await Promise.all(paths.map((path) => getPackage(path, multiContext)));
+	const packages = allPackages.filter((p) => {
+		if (p.manifest.private === true) {
+			logger.warn(`[${p.name}] is private, will be ignored`);
+			return false;
+		}
+
+		return true;
+	});
 	packages.forEach((pkg) => {
 		// Once we load all the packages we can find their cross refs
 		// Make a list of local dependencies.

--- a/test/fixtures/yarnWorkspacesPrivatePackage/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "msr-test-yarn",
+	"author": "Dave Houlbrooke <dave@shax.com>",
+	"version": "0.0.0-semantically-released",
+	"private": true,
+	"license": "0BSD",
+	"engines": {
+		"node": ">=8.3"
+	},
+	"workspaces": [
+		"packages/*"
+	],
+	"release": {
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator"
+		],
+		"noCi": true
+	}
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/a/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-a",
+	"version": "0.0.0",
+	"peerDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/b/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "msr-test-b",
+	"version": "0.0.0",
+	"dependencies": {
+		"msr-test-a": "*"
+	},
+	"devDependencies": {
+		"msr-test-c": "*",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/.releaserc.json
@@ -1,0 +1,3 @@
+{
+	"tagFormat": "multi-semantic-release-test-c@v${version}"
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-c",
+	"version": "0.0.0",
+	"devDependencies": {
+		"msr-test-b": "*",
+		"msr-test-d": "*"
+	}
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/d/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/d/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-d",
+	"version": "0.0.0"
+}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/e/package.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/e/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "msr-test-e",
+	"private": true,
+	"version": "0.0.0",
+	"peerDependencies": {
+		"msr-test-c": "*"
+	}
+}

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1155,4 +1155,126 @@ describe("multiSemanticRelease()", () => {
 			},
 		});
 	});
+	test("With private packages", async () => {
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspacesPrivatePackage/`, cwd);
+		const sha = gitCommitAll(cwd, "feat: Initial release");
+		const url = gitInitOrigin(cwd);
+		gitPush(cwd);
+
+		// Capture output.
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		// Call multiSemanticRelease()
+		// Doesn't include plugins that actually publish.
+		const multiSemanticRelease = require("../../");
+		const result = await multiSemanticRelease(
+			[
+				`packages/a/package.json`,
+				`packages/b/package.json`,
+				`packages/c/package.json`,
+				`packages/d/package.json`,
+				`packages/e/package.json`,
+			],
+			{},
+			{ cwd, stdout, stderr }
+		);
+
+		// Get stdout and stderr output.
+		const err = stderr.getContentsAsString("utf8");
+		expect(err).toBe(false);
+		const out = stdout.getContentsAsString("utf8");
+		expect(out).toMatch("Started multirelease! Loading 5 packages...");
+		expect(out).toMatch("Loaded package msr-test-a");
+		expect(out).toMatch("Loaded package msr-test-b");
+		expect(out).toMatch("Loaded package msr-test-c");
+		expect(out).toMatch("Loaded package msr-test-d");
+		expect(out).toMatch("[msr-test-e] is private, will be ignored");
+		expect(out).toMatch("Queued 4 packages! Starting release...");
+		expect(out).toMatch("Created tag msr-test-a@1.0.0");
+		expect(out).toMatch("Created tag msr-test-b@1.0.0");
+		expect(out).toMatch("Created tag msr-test-c@1.0.0");
+		expect(out).toMatch("Created tag msr-test-d@1.0.0");
+		expect(out).toMatch("Released 4 of 4 packages, semantically!");
+
+		// A.
+		expect(result[0].name).toBe("msr-test-a");
+		expect(result[0].result.lastRelease).toEqual({});
+		expect(result[0].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-a@1.0.0",
+			type: "minor",
+			version: "1.0.0",
+		});
+		expect(result[0].result.nextRelease.notes).toMatch("# msr-test-a 1.0.0");
+		expect(result[0].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[0].result.nextRelease.notes).toMatch("### Dependencies\n\n* **msr-test-c:** upgraded to 1.0.0");
+
+		// B.
+		expect(result[1].name).toBe("msr-test-b");
+		expect(result[1].result.lastRelease).toEqual({});
+		expect(result[1].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-b@1.0.0",
+			type: "minor",
+			version: "1.0.0",
+		});
+		expect(result[1].result.nextRelease.notes).toMatch("# msr-test-b 1.0.0");
+		expect(result[1].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[1].result.nextRelease.notes).toMatch(
+			"### Dependencies\n\n* **msr-test-a:** upgraded to 1.0.0\n* **msr-test-c:** upgraded to 1.0.0"
+		);
+
+		// C.
+		expect(result[2].name).toBe("msr-test-c");
+		expect(result[2].result.lastRelease).toEqual({});
+		expect(result[2].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-c@1.0.0",
+			type: "minor",
+			version: "1.0.0",
+		});
+		expect(result[2].result.nextRelease.notes).toMatch("# msr-test-c 1.0.0");
+		expect(result[2].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[2].result.nextRelease.notes).toMatch("### Dependencies\n\n* **msr-test-b:** upgraded to 1.0.0");
+
+		// D.
+		expect(result[3].name).toBe("msr-test-d");
+		expect(result[3].result.lastRelease).toEqual({});
+		expect(result[3].result.nextRelease).toMatchObject({
+			gitHead: sha,
+			gitTag: "msr-test-d@1.0.0",
+			type: "minor",
+			version: "1.0.0",
+		});
+		expect(result[3].result.nextRelease.notes).toMatch("# msr-test-d 1.0.0");
+		expect(result[3].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+		expect(result[3].result.nextRelease.notes).not.toMatch("### Dependencies");
+
+		// ONLY four times.
+		expect(result).toHaveLength(4);
+
+		// Check manifests.
+		expect(require(`${cwd}/packages/a/package.json`)).toMatchObject({
+			peerDependencies: {
+				"msr-test-c": "1.0.0",
+			},
+		});
+		expect(require(`${cwd}/packages/b/package.json`)).toMatchObject({
+			dependencies: {
+				"msr-test-a": "1.0.0",
+			},
+			devDependencies: {
+				"msr-test-c": "1.0.0",
+			},
+		});
+		expect(require(`${cwd}/packages/c/package.json`)).toMatchObject({
+			devDependencies: {
+				"msr-test-b": "1.0.0",
+				"msr-test-d": "1.0.0",
+			},
+		});
+	});
 });


### PR DESCRIPTION
- Fixes https://github.com/dhoulb/multi-semantic-release/issues/62 

**Changes:**
Private packages will be ignored by `multi-semantic-release` as they're ignored by `semantic-release`. This should fix infinite loop.