### PR TITLE
fix(getPackagePaths): avoid files like ng-package.json

### DIFF
--- a/lib/getPackagePaths.js
+++ b/lib/getPackagePaths.js
@@ -42,7 +42,7 @@ function getPackagePaths(cwd, ignorePackages = null) {
 		absolute: true,
 		gitignore: true,
 		deep: 1,
-	}).filter((f) => /package.json$/.test(f));
+	}).filter((f) => /\/package\.json$/.test(f));
 
 	// Must have at least one workspace-package.
 	if (!workspacePackages.length)


### PR DESCRIPTION
I have an issue where not only `package.json` files are returned but also `ng-package.json` files.
Those are valid configuration files used by [ng-packgr](https://github.com/ng-packagr/ng-packagr).

This PR fixes this by making sure the filename (and not the end of the file path) matches 'package.json'.