### PR TITLE
fix: handle pnpm monorepo `workspace:^` version correctly (#111)

### DIFF
--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -244,6 +244,12 @@ const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "overrid
 	//no change...
 	if (currentVersion === nextVersion) return currentVersion;
 
+	// handle cases of "workspace protocol" defined in pnpm, whose version starts with "workspace:"
+	// reference: https://pnpm.io/workspaces#publishing-workspace-packages
+	if (currentVersion.startsWith("workspace:")) {
+		return resolveNextVersionWithPnpmWorkspaceProtocol(currentVersion, nextVersion, bumpStrategy, prefix);
+	}
+
 	// Check the next pkg version against its current references.
 	// If it matches (`*` matches to any, `1.1.0` matches `1.1.x`, `1.5.0` matches to `^1.0.0` and so on)
 	// release will not be triggered, if not `override` strategy will be applied instead.
@@ -271,6 +277,45 @@ const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "overrid
 	// "override"
 	// By default next package version would be set as is for the all dependants.
 	return prefix + nextVersion;
+};
+
+/**
+ * Resolve next version of dependency based on bumpStrategy,
+ * in case of current dep version (currentVersion) uses "workspace protocol" defined in pnpm.
+ * See {@link https://pnpm.io/workspaces#publishing-workspace-packages}
+ *
+ * @param {string} currentVersion Current dep version, must starting with "workspace:"
+ * @param {string} nextVersion Next release type: patch, minor, major
+ * @param {string|undefined} bumpStrategy Resolution strategy: inherit, override, satisfy
+ * @param {string} prefix Dependency version prefix to be attached if `bumpStrategy='override'`. ^ | ~ | '' (defaults to empty string)
+ * @returns {string} Next dependency version
+ */
+const resolveNextVersionWithPnpmWorkspaceProtocol = (
+	currentVersion,
+	nextVersion,
+	bumpStrategy = "override",
+	prefix = ""
+) => {
+	// in "override" strategy, workspace protocol should also be overridden
+	if (bumpStrategy === "override") {
+		return resolveNextVersion("", nextVersion, bumpStrategy, prefix);
+	}
+
+	// remove "workspace:" prefix of current version
+	const currentVersionRemovingWorkspace = currentVersion.replace("workspace:", "");
+	switch (currentVersionRemovingWorkspace) {
+		// case of "workspace:*"
+		case "*":
+			return nextVersion;
+		// case of "workspace:~" and "workspace:^"
+		case "~":
+		case "^":
+			return currentVersionRemovingWorkspace + nextVersion;
+		// other cases (e. g. "workspace:~2.0.0") and wrong cases (e. g. "workspace:x")
+		// these should be treated normally as if "workspace:" was removed (e. g. "~2.0.0" and "x")
+		default:
+			return resolveNextVersion(currentVersionRemovingWorkspace, nextVersion, bumpStrategy, prefix);
+	}
 };
 
 /**

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -241,14 +241,11 @@ const manifestUpdateNecessary = (scope, name, nextVersion, bumpStrategy, prefix)
  * @internal
  */
 const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "override", prefix = "") => {
+	// handle cases of "workspace protocol" defined in yarn and pnpm workspace, whose version starts with "workspace:"
+	currentVersion = substituteWorkspaceVersion(currentVersion, nextVersion);
+
 	//no change...
 	if (currentVersion === nextVersion) return currentVersion;
-
-	// handle cases of "workspace protocol" defined in pnpm, whose version starts with "workspace:"
-	// reference: https://pnpm.io/workspaces#publishing-workspace-packages
-	if (currentVersion.startsWith("workspace:")) {
-		return resolveNextVersionWithPnpmWorkspaceProtocol(currentVersion, nextVersion, bumpStrategy, prefix);
-	}
 
 	// Check the next pkg version against its current references.
 	// If it matches (`*` matches to any, `1.1.0` matches `1.1.x`, `1.5.0` matches to `^1.0.0` and so on)
@@ -266,10 +263,10 @@ const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "overrid
 		const currentChunks = currentVersion.split(sep);
 		// prettier-ignore
 		const resolvedChunks = currentChunks.map((chunk, i) =>
-			nextChunks[i]
-				? chunk.replace(/\d+/, nextChunks[i])
-				: chunk
-		);
+            nextChunks[i]
+                ? chunk.replace(/\d+/, nextChunks[i])
+                : chunk
+        );
 
 		return resolvedChunks.join(sep);
 	}
@@ -280,42 +277,22 @@ const resolveNextVersion = (currentVersion, nextVersion, bumpStrategy = "overrid
 };
 
 /**
- * Resolve next version of dependency based on bumpStrategy,
- * in case of current dep version (currentVersion) uses "workspace protocol" defined in pnpm.
- * See {@link https://pnpm.io/workspaces#publishing-workspace-packages}
+ * Substitute "workspace:" in currentVersion
+ * See:
+ * {@link https://yarnpkg.com/features/workspaces#publishing-workspaces}
+ * {@link https://pnpm.io/workspaces#publishing-workspace-packages}
  *
- * @param {string} currentVersion Current dep version, must starting with "workspace:"
- * @param {string} nextVersion Next release type: patch, minor, major
- * @param {string|undefined} bumpStrategy Resolution strategy: inherit, override, satisfy
- * @param {string} prefix Dependency version prefix to be attached if `bumpStrategy='override'`. ^ | ~ | '' (defaults to empty string)
- * @returns {string} Next dependency version
+ * @param {string} currentVersion Current version, may start with "workspace:"
+ * @param {string} nextVersion Next version
+ * @returns {string} current version without "workspace:"
  */
-const resolveNextVersionWithPnpmWorkspaceProtocol = (
-	currentVersion,
-	nextVersion,
-	bumpStrategy = "override",
-	prefix = ""
-) => {
-	// in "override" strategy, workspace protocol should also be overridden
-	if (bumpStrategy === "override") {
-		return resolveNextVersion("", nextVersion, bumpStrategy, prefix);
-	}
+const substituteWorkspaceVersion = (currentVersion, nextVersion) => {
+	if (currentVersion.startsWith("workspace:")) {
+		const [, range, caret] = /^workspace:(([\^~*])?.*)$/.exec(currentVersion);
 
-	// remove "workspace:" prefix of current version
-	const currentVersionRemovingWorkspace = currentVersion.replace("workspace:", "");
-	switch (currentVersionRemovingWorkspace) {
-		// case of "workspace:*"
-		case "*":
-			return nextVersion;
-		// case of "workspace:~" and "workspace:^"
-		case "~":
-		case "^":
-			return currentVersionRemovingWorkspace + nextVersion;
-		// other cases (e. g. "workspace:~2.0.0") and wrong cases (e. g. "workspace:x")
-		// these should be treated normally as if "workspace:" was removed (e. g. "~2.0.0" and "x")
-		default:
-			return resolveNextVersion(currentVersionRemovingWorkspace, nextVersion, bumpStrategy, prefix);
+		return caret === range ? (caret === "*" ? nextVersion : caret + nextVersion) : range;
 	}
+	return currentVersion;
 };
 
 /**

--- a/lib/updateDeps.js
+++ b/lib/updateDeps.js
@@ -351,7 +351,7 @@ const updateManifestDeps = (pkg, writeOut = true, bumpStrategy = "override", pre
 		scopes.forEach((scope) => {
 			if (scope[dependency.name]) {
 				scope[dependency.name] = resolveNextVersion(
-					get(dependency, "_lastRelease.version", "0.0.0"),
+					scope[dependency.name],
 					release.version,
 					bumpStrategy,
 					prefix

--- a/test/fixtures/yarnWorkspacesRanges/package.json
+++ b/test/fixtures/yarnWorkspacesRanges/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "msr-test-yarn",
+	"author": "Dave Houlbrooke <dave@shax.com>",
+	"version": "0.0.0-semantically-released",
+	"private": true,
+	"license": "0BSD",
+	"engines": {
+		"node": ">=8.3"
+	},
+	"workspaces": [
+		"packages/*"
+	],
+	"release": {
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator"
+		],
+		"noCi": true
+	}
+}

--- a/test/fixtures/yarnWorkspacesRanges/packages/a/package.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/a/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "msr-test-a",
+	"version": "0.0.0",
+	"dependencies": {
+		"msr-test-b": "workspace:*"
+	},
+	"devDependencies": {
+		"msr-test-c": "workspace:^"
+	},
+	"peerDependencies": {
+		"msr-test-d": "workspace:~",
+		"left-pad": "latest"
+	}
+}

--- a/test/fixtures/yarnWorkspacesRanges/packages/b/package.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/b/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "msr-test-b",
+	"version": "0.0.0",
+	"optionalDependencies": {
+		"msr-test-d": "workspace:^0.0.0"
+	}
+}

--- a/test/fixtures/yarnWorkspacesRanges/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/c/.releaserc.json
@@ -1,0 +1,3 @@
+{
+	"tagFormat": "multi-semantic-release-test-c@v${version}"
+}

--- a/test/fixtures/yarnWorkspacesRanges/packages/c/package.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/c/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-c",
+	"version": "0.0.0"
+}

--- a/test/fixtures/yarnWorkspacesRanges/packages/d/package.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/d/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "msr-test-d",
+	"version": "0.0.0"
+}

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1729,21 +1729,21 @@ describe("multiSemanticRelease()", () => {
 			// Check manifests.
 			expect(require(`${cwd}/packages/a/package.json`)).toMatchObject({
 				peerDependencies: {
-					"msr-test-c": strategy === "inherit" ? "1.0.0" : prefix + "1.0.0",
+					"msr-test-c": strategy === "inherit" ? "^1.0.0" : prefix + "1.0.0",
 				},
 			});
 			expect(require(`${cwd}/packages/b/package.json`)).toMatchObject({
 				dependencies: {
-					"msr-test-a": strategy === "inherit" ? "1.0.0" : prefix + "1.0.0",
+					"msr-test-a": strategy === "inherit" ? "^1.0.0" : prefix + "1.0.0",
 				},
 				devDependencies: {
-					"msr-test-c": strategy === "inherit" ? "1.0.0" : prefix + "1.0.0",
+					"msr-test-c": strategy === "inherit" ? "^1.0.0" : prefix + "1.0.0",
 				},
 			});
 			expect(require(`${cwd}/packages/c/package.json`)).toMatchObject({
 				devDependencies: {
-					"msr-test-b": strategy === "inherit" ? "1.0.0" : prefix + "1.0.0",
-					"msr-test-d": strategy === "inherit" ? "1.0.0" : prefix + "1.0.0",
+					"msr-test-b": strategy === "inherit" ? "^1.0.0" : prefix + "1.0.0",
+					"msr-test-d": strategy === "inherit" ? "^1.0.0" : prefix + "1.0.0",
 				},
 			});
 		});

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -1748,4 +1748,128 @@ describe("multiSemanticRelease()", () => {
 			});
 		});
 	});
+	describe.each([
+		["override", "^"],
+		["satisfy", "^"],
+		["inherit", "^"],
+	])("With Yarn Workspace Ranges & deps.bump=%s & deps.prefix=%s", (strategy, prefix) => {
+		test('should replace "workspace:" with correct version', async () => {
+			// Create Git repo with copy of Yarn workspaces fixture.
+			const cwd = gitInit();
+			copyDirectory(`test/fixtures/yarnWorkspacesRanges/`, cwd);
+			const sha = gitCommitAll(cwd, "feat: Initial release");
+			gitInitOrigin(cwd);
+			gitPush(cwd);
+
+			// Capture output.
+			const stdout = new WritableStreamBuffer();
+			const stderr = new WritableStreamBuffer();
+
+			// Call multiSemanticRelease()
+			// Doesn't include plugins that actually publish.
+			const multiSemanticRelease = require("../../");
+			const result = await multiSemanticRelease(
+				[
+					`packages/a/package.json`,
+					`packages/b/package.json`,
+					`packages/c/package.json`,
+					`packages/d/package.json`,
+				],
+				{},
+				{ cwd, stdout, stderr },
+				{ deps: { bump: strategy, prefix } }
+			);
+
+			// Get stdout and stderr output.
+			const err = stderr.getContentsAsString("utf8");
+			expect(err).toBe(false);
+			const out = stdout.getContentsAsString("utf8");
+			expect(out).toMatch("Started multirelease! Loading 4 packages...");
+			expect(out).toMatch("Loaded package msr-test-a");
+			expect(out).toMatch("Loaded package msr-test-b");
+			expect(out).toMatch("Loaded package msr-test-c");
+			expect(out).toMatch("Loaded package msr-test-d");
+			expect(out).toMatch("Queued 4 packages! Starting release...");
+			expect(out).toMatch("Created tag msr-test-a@1.0.0");
+			expect(out).toMatch("Created tag msr-test-b@1.0.0");
+			expect(out).toMatch("Created tag msr-test-c@1.0.0");
+			expect(out).toMatch("Created tag msr-test-d@1.0.0");
+			expect(out).toMatch("Released 4 of 4 packages, semantically!");
+
+			// A.
+			expect(result[0].name).toBe("msr-test-a");
+			expect(result[0].result.lastRelease).toEqual({});
+			expect(result[0].result.nextRelease).toMatchObject({
+				gitHead: sha,
+				gitTag: "msr-test-a@1.0.0",
+				type: "minor",
+				version: "1.0.0",
+			});
+			expect(result[0].result.nextRelease.notes).toMatch("# msr-test-a 1.0.0");
+			expect(result[0].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+			expect(result[0].result.nextRelease.notes).toMatch(
+				"### Dependencies\n\n* **msr-test-b:** upgraded to 1.0.0\n* **msr-test-c:** upgraded to 1.0.0"
+			);
+
+			// B.
+			expect(result[1].name).toBe("msr-test-b");
+			expect(result[1].result.lastRelease).toEqual({});
+			expect(result[1].result.nextRelease).toMatchObject({
+				gitHead: sha,
+				gitTag: "msr-test-b@1.0.0",
+				type: "minor",
+				version: "1.0.0",
+			});
+			expect(result[1].result.nextRelease.notes).toMatch("# msr-test-b 1.0.0");
+			expect(result[1].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+			expect(result[1].result.nextRelease.notes).toMatch(
+				"### Dependencies\n\n* **msr-test-d:** upgraded to 1.0.0"
+			);
+
+			// C.
+			expect(result[2].name).toBe("msr-test-c");
+			expect(result[2].result.lastRelease).toEqual({});
+			expect(result[2].result.nextRelease).toMatchObject({
+				gitHead: sha,
+				gitTag: "msr-test-c@1.0.0",
+				type: "minor",
+				version: "1.0.0",
+			});
+			expect(result[2].result.nextRelease.notes).toMatch("# msr-test-c 1.0.0");
+			expect(result[2].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+
+			// D.
+			expect(result[3].name).toBe("msr-test-d");
+			expect(result[3].result.lastRelease).toEqual({});
+			expect(result[3].result.nextRelease).toMatchObject({
+				gitHead: sha,
+				gitTag: "msr-test-d@1.0.0",
+				type: "minor",
+				version: "1.0.0",
+			});
+			expect(result[3].result.nextRelease.notes).toMatch("# msr-test-d 1.0.0");
+			expect(result[3].result.nextRelease.notes).toMatch("### Features\n\n* Initial release");
+
+			// ONLY four times.
+			expect(result).toHaveLength(4);
+
+			// Check manifests.
+			expect(require(`${cwd}/packages/a/package.json`)).toMatchObject({
+				dependencies: {
+					"msr-test-b": "1.0.0",
+				},
+				devDependencies: {
+					"msr-test-c": strategy === "override" ? prefix + "1.0.0" : "^1.0.0",
+				},
+				peerDependencies: {
+					"msr-test-d": strategy === "override" ? prefix + "1.0.0" : "~1.0.0",
+				},
+			});
+			expect(require(`${cwd}/packages/b/package.json`)).toMatchObject({
+				optionalDependencies: {
+					"msr-test-d": strategy === "override" ? prefix + "1.0.0" : "^1.0.0",
+				},
+			});
+		});
+	});
 });

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -26,6 +26,30 @@ describe("resolveNextVersion()", () => {
 		["*", "2.0.0", "inherit", "*"],
 		["~1.0", "2.0.0", "inherit", "~2.0"],
 		["~2.0", "2.1.0", "inherit", "~2.1"],
+
+		// cases of "workspace protocol" defined in pnpm
+		// reference: https://pnpm.io/workspaces#publishing-workspace-packages
+		["workspace:*", "1.0.1", undefined, "1.0.1"],
+		["workspace:*", "1.0.1", "override", "1.0.1"],
+
+		["workspace:*", "1.3.0", "satisfy", "1.3.0"],
+		["workspace:~", "1.0.1", "satisfy", "~1.0.1"],
+		["workspace:^", "1.3.0", "satisfy", "^1.3.0"],
+		// the following cases should be treated as if "workspace:" was removed
+		["workspace:^1.0.0", "1.0.1", "satisfy", "^1.0.0"],
+		["workspace:^1.2.0", "1.3.0", "satisfy", "^1.2.0"],
+		["workspace:1.2.x", "1.2.2", "satisfy", "1.2.x"],
+
+		["workspace:*", "1.3.0", "inherit", "1.3.0"],
+		["workspace:~", "1.1.0", "inherit", "~1.1.0"],
+		["workspace:^", "2.0.0", "inherit", "^2.0.0"],
+		// the following cases should be treated as if "workspace:" was removed
+		["workspace:~1.0.0", "1.1.0", "inherit", "~1.1.0"],
+		["workspace:1.2.x", "1.2.1", "inherit", "1.2.x"],
+		["workspace:1.2.x", "1.3.0", "inherit", "1.3.x"],
+		["workspace:^1.0.0", "2.0.0", "inherit", "^2.0.0"],
+		["workspace:~1.0", "2.0.0", "inherit", "~2.0"],
+		["workspace:~2.0", "2.1.0", "inherit", "~2.1"],
 	]
 
 	cases.forEach(([currentVersion, nextVersion, strategy, resolvedVersion]) => {

--- a/test/lib/updateDeps.test.js
+++ b/test/lib/updateDeps.test.js
@@ -27,8 +27,7 @@ describe("resolveNextVersion()", () => {
 		["~1.0", "2.0.0", "inherit", "~2.0"],
 		["~2.0", "2.1.0", "inherit", "~2.1"],
 
-		// cases of "workspace protocol" defined in pnpm
-		// reference: https://pnpm.io/workspaces#publishing-workspace-packages
+		// cases of "workspace protocol" defined in yarn and pnpm
 		["workspace:*", "1.0.1", undefined, "1.0.1"],
 		["workspace:*", "1.0.1", "override", "1.0.1"],
 


### PR DESCRIPTION
resolve #111: support of replacing pnpm's `workspace:` dependencies version. [pnpm docs](https://pnpm.io/workspaces#publishing-workspace-packages)

**I modify current existing tests**, since I think it should work like this :P. Anyway, I may have misunderstanding on this project, so I'm happy to discuss with contributor.

After I'm allowed to modify current existing tests, I will add integration tests on monorepo that uses pnpm `workspace:` protocol.

---------

**Update: integration tests added.**