### PR TITLE
fix: respect an explicitly-configured tagFormat instead of always overriding it

### DIFF
--- a/lib/multiSemanticRelease.js
+++ b/lib/multiSemanticRelease.js
@@ -149,6 +149,11 @@ async function getPackage(path, { globalOptions, inputOptions, env, cwd, stdout,
 	// We merge this ourselves because package-specific options can override global options.
 	const finalOptions = Object.assign({}, globalOptions, pkgOptions, inputOptions);
 
+	// Capture an explicitly-configured `tagFormat` (from the global or package config)
+	// BEFORE semantic-release's get-config injects its `v${version}` default below, so
+	// releasePackage() can tell an author-set `tagFormat` apart from the default.
+	const configuredTagFormat = finalOptions.tagFormat;
+
 	// Make a fake logger so semantic-release's get-config doesn't fail.
 	const logger = { error() {}, log() {} };
 
@@ -157,7 +162,7 @@ async function getPackage(path, { globalOptions, inputOptions, env, cwd, stdout,
 	const { options, plugins } = await getConfigSemantic({ cwd: dir, env, stdout, stderr, logger }, finalOptions);
 
 	// Return package object.
-	return { path, dir, name, manifest, deps, options, plugins, loggerRef: logger };
+	return { path, dir, name, manifest, deps, options, plugins, loggerRef: logger, configuredTagFormat };
 }
 
 /**
@@ -173,7 +178,7 @@ async function getPackage(path, { globalOptions, inputOptions, env, cwd, stdout,
  */
 async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 	// Vars.
-	const { options: pkgOptions, name, dir } = pkg;
+	const { options: pkgOptions, name, dir, configuredTagFormat } = pkg;
 	const { env, stdout, stderr } = multiContext;
 
 	// Make an 'inline plugin' for this package.
@@ -191,7 +196,11 @@ async function releasePackage(pkg, createInlinePlugin, multiContext, flags) {
 	// Add the package name into tagFormat.
 	// Thought about doing a single release for the tag (merging several packages), but it's impossible to prevent Github releasing while allowing NPM to continue.
 	// It'd also be difficult to merge all the assets into one release without full editing/overriding the plugins.
-	options.tagFormat = name + "@${version}";
+	// Respect an explicitly-configured `tagFormat` (e.g. to drop an npm scope from the
+	// git tag) when the package provides one; otherwise default to namespacing the tag
+	// by the package name so per-package tags don't collide on semantic-release's
+	// default `v${version}`.
+	options.tagFormat = configuredTagFormat || name + "@${version}";
 
 	// These options are needed for plugins that do not rely on `pluginOptions` and extract them independently.
 	options._pkgOptions = pkgOptions;

--- a/test/fixtures/boltWorkspaces/packages/c/.releaserc.json
+++ b/test/fixtures/boltWorkspaces/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/boltWorkspacesIgnore/packages/c/.releaserc.json
+++ b/test/fixtures/boltWorkspacesIgnore/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/boltWorkspacesUndefined/packages/c/.releaserc.json
+++ b/test/fixtures/boltWorkspacesUndefined/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/pkgRootOptions/packages/c/.releaserc.json
+++ b/test/fixtures/pkgRootOptions/packages/c/.releaserc.json
@@ -1,14 +1,13 @@
 {
-    "tagFormat": "multi-semantic-release-test-c@v${version}",
-    "plugins": [
-        "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
-        [
-            "@semantic-release/npm",
-            {
-                "pkgRoot": "../../dist/c",
-                "npmPublish": false
-            }
-        ]
-    ]
+	"plugins": [
+		"@semantic-release/commit-analyzer",
+		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/npm",
+			{
+				"pkgRoot": "../../dist/c",
+				"npmPublish": false
+			}
+		]
+	]
 }

--- a/test/fixtures/pnpmWorkspace/packages/c/.releaserc.json
+++ b/test/fixtures/pnpmWorkspace/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/pnpmWorkspaceIgnore/packages/c/.releaserc.json
+++ b/test/fixtures/pnpmWorkspaceIgnore/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/pnpmWorkspaceUndefined/packages/c/.releaserc.json
+++ b/test/fixtures/pnpmWorkspaceUndefined/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspaces/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspaces/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspaces2Packages/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspaces2Packages/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesIgnore/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesIgnore/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesIgnoreSplit/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesIgnoreSplit/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesPackages/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesPackages/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesPackagesCarret/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesPackagesCarret/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesPrivatePackage/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/fixtures/yarnWorkspacesRanges/packages/c/.releaserc.json
+++ b/test/fixtures/yarnWorkspacesRanges/packages/c/.releaserc.json
@@ -1,3 +1,1 @@
-{
-	"tagFormat": "multi-semantic-release-test-c@v${version}"
-}
+{}

--- a/test/lib/multiSemanticRelease.test.js
+++ b/test/lib/multiSemanticRelease.test.js
@@ -28,6 +28,50 @@ const env = {
 
 // Tests.
 describe("multiSemanticRelease()", () => {
+	test("Respects a package's explicitly-configured tagFormat", async () => {
+		// Create Git repo with copy of Yarn workspaces fixture.
+		const cwd = gitInit();
+		copyDirectory(`test/fixtures/yarnWorkspaces/`, cwd);
+
+		// Give one package a custom tagFormat. This proves multi-semantic-release
+		// honours an explicitly-configured tagFormat instead of always namespacing
+		// the tag by the package name — e.g. so a scoped package can keep its npm
+		// scope while tagging without it.
+		writeFileSync(`${cwd}/packages/c/.releaserc.json`, JSON.stringify({ tagFormat: "tagged-c-${version}" }));
+
+		const sha = gitCommitAll(cwd, "feat: Initial release");
+		const url = gitInitOrigin(cwd);
+		gitPush(cwd);
+
+		const stdout = new WritableStreamBuffer();
+		const stderr = new WritableStreamBuffer();
+
+		const multiSemanticRelease = require("../../");
+		const result = await multiSemanticRelease(
+			[
+				`packages/a/package.json`,
+				`packages/b/package.json`,
+				`packages/c/package.json`,
+				`packages/d/package.json`,
+			],
+			{},
+			{ cwd, stdout, stderr, env }
+		);
+
+		const out = stdout.getContentsAsString("utf8");
+		// Package c uses its configured tagFormat...
+		expect(out).toMatch("Created tag tagged-c-1.0.0");
+		// ...while the other packages still default to `${name}@${version}`.
+		expect(out).toMatch("Created tag msr-test-d@1.0.0");
+
+		const cResult = result.find((pkg) => pkg.name === "msr-test-c");
+		expect(cResult.result.nextRelease).toMatchObject({
+			gitTag: "tagged-c-1.0.0",
+			name: "tagged-c-1.0.0",
+			version: "1.0.0",
+		});
+	});
+
 	test("Initial commit (changes in all packages)", async () => {
 		// Create Git repo with copy of Yarn workspaces fixture.
 		const cwd = gitInit();


### PR DESCRIPTION
Hi 👋

### Problem

`releasePackage()` sets `options.tagFormat = name + "@${version}"` unconditionally, overriding any `tagFormat` an author has configured for a package. This silently discards a documented semantic-release option, and there is no way to opt out.

This matters for monorepos that contain a **scoped** package. The tag is derived from the npm name, so a package named `@scope/foo` is tagged and GitHub-released as `@scope/foo@1.2.3`, while every unscoped package is tagged `bar@1.2.3`. There's currently no way to keep the npm scope (for publishing) while tagging without it – the npm name and the git tag are forced to share a format.

Interestingly, the test fixtures already demonstrate this: `test/fixtures/*/packages/c/.releaserc.json` set `tagFormat`, yet the suite asserts the name-based tag (`msr-test-c@1.0.0`), i.e. the configured value is dropped.

### Change

Respect an explicitly-configured `tagFormat`, falling back to the existing `${name}@${version}` default when none is set.

The configured value is captured from the merged package/global config **before** semantic-release's `get-config` injects its `v${version}` default, so an author-set `tagFormat` is distinguishable from the default. Behaviour is unchanged for every package that doesn't set `tagFormat`.

### Example

```js
// packages/blocks/release.config.js — npm name stays @automattic/newspack-blocks,
// but the git tag / GitHub release become newspack-blocks@x.y.z
module.exports = { tagFormat: 'newspack-blocks@${version}' };
```

### Why this matters to us

We're carrying this exact change as a one-line `pnpm patch` against `multi-semantic-release` in production to get unscoped tags for a single scoped package in our monorepo. We'd much rather drop the patch and configure `tagFormat` the supported way – hence this PR.

### Backward compatibility

Fully backward compatible: packages without an explicit `tagFormat` keep tagging as `${name}@${version}`.

### Tests

- Added a dedicated test asserting a package with a configured `tagFormat` is tagged accordingly while its siblings keep the default format.
- The `c` fixtures set a `tagFormat` that was previously ignored (the assertions expected the name-based tag). Since respecting it would otherwise change ~20 unrelated tag assertions, the inert `tagFormat` is removed from those fixtures, keeping those tests focused on what they actually cover.

Full suite green locally (`198 passed`).